### PR TITLE
Revamp login and dashboard styling

### DIFF
--- a/assets/app.css
+++ b/assets/app.css
@@ -11,7 +11,7 @@
 }
 
 *{box-sizing:border-box}
-html,body{margin:0;background:var(--bg);color:var(--text);font:14px/1.5 ui-sans-serif,system-ui,Segoe UI,Roboto,Arial}
+html,body{margin:0;background:transparent;color:var(--text);font:14px/1.5 ui-sans-serif,system-ui,Segoe UI,Roboto,Arial}
 
 a{color:var(--brand);text-decoration:none}
 a:hover{opacity:.9}
@@ -73,23 +73,93 @@ a:hover{opacity:.9}
 .hrq-form label{display:block;margin:10px 0 6px;font-weight:600}
 
 /* ==== Auth new look ==== */
-.hrissq-auth-wrap{min-height:70vh;display:grid;place-items:center;padding:24px;background:#f3f4f6}
-.auth-card{width:100%;max-width:420px;background:#0f4a43; /* hijau SQ tua sebagai border */
-  border-radius:24px;padding:14px}
-.auth-card .auth-form, .auth-card h2{
-  background:#fff;border-radius:18px;padding:20px
-}
-.auth-card h2{margin:0 0 12px;text-align:center;font-size:28px;line-height:1.1;font-weight:800}
-.auth-form label{display:block;margin:10px 0 6px;color:#111827;font-weight:600}
-.auth-form input{width:100%;padding:12px 14px;border:1px solid #e5e7eb;border-radius:12px;font-size:14px}
+.hrissq-auth-wrap{min-height:60vh;display:flex;align-items:center;justify-content:center;padding:48px 16px;background:transparent}
+.auth-card{width:100%;max-width:460px;padding:32px 28px;border-radius:24px;border:1px solid rgba(15,23,42,.12);background:rgba(255,255,255,.88);box-shadow:0 18px 45px rgba(15,23,42,.12);backdrop-filter:blur(8px)}
+.auth-header{text-align:center;margin-bottom:20px}
+.auth-header h2{margin:0;font-size:28px;font-weight:800;color:var(--text)}
+.auth-header p{margin:8px 0 0;color:var(--muted);font-size:14px}
+.auth-form{display:flex;flex-direction:column;gap:14px}
+.auth-form label{display:block;font-weight:600;color:var(--text)}
+.auth-form input{width:100%;padding:12px 14px;border:1px solid rgba(15,23,42,.12);border-radius:12px;font-size:14px;background:rgba(255,255,255,.92)}
+.auth-form input:focus{border-color:var(--brand);box-shadow:0 0 0 4px var(--ring);outline:none}
 .req{color:#ef4444}
-.pw-row{display:flex;gap:8px;align-items:center}
-.pw-row .eye{white-space:nowrap;border:1px solid #e5e7eb;background:#f8fafc;color:#334155;padding:10px 12px;border-radius:10px;cursor:pointer}
-.btn-primary{width:100%;margin-top:14px;background:#0f766e;color:#fff;border:none;border-radius:12px;padding:12px 16px;font-weight:800;cursor:pointer}
-.btn-light{background:#e5e7eb;color:#111827;border:none;border-radius:10px;padding:10px 14px;cursor:pointer}
-.link-forgot{margin-top:10px;background:none;border:none;color:#0ea5e9;font-weight:700;cursor:pointer}
-.msg{margin-top:8px;font-size:13px;color:#b91c1c}
+.pw-row{display:flex;gap:10px;align-items:center}
+.pw-row input{flex:1 1 auto}
+.pw-row .eye{flex:0 0 auto;border:1px solid rgba(15,23,42,.12);background:rgba(15,23,42,.05);color:var(--text);padding:10px 14px;border-radius:10px;cursor:pointer;font-weight:600;font-size:13px}
+.btn-primary{background:var(--brand);color:#fff;border:none;border-radius:12px;padding:12px 16px;font-weight:700;cursor:pointer;transition:filter .2s ease,transform .2s ease}
+.btn-primary:hover{filter:brightness(1.05);transform:translateY(-1px)}
+.auth-form .btn-primary{width:100%;margin-top:6px}
+.btn-light{background:rgba(15,23,42,.05);color:var(--text);border:1px solid rgba(15,23,42,.1);border-radius:10px;padding:10px 14px;cursor:pointer;font-weight:600}
+.btn-light:hover{filter:brightness(1.02)}
+.link-forgot{margin-top:4px;background:none;border:none;color:var(--brand-2);font-weight:700;cursor:pointer;text-align:center}
+.msg{margin-top:6px;font-size:13px;color:#b91c1c;min-height:18px}
 .msg.ok{color:#065f46}
+
+/* ==== Dashboard layout ==== */
+.hrissq-dashboard{display:grid;grid-template-columns:260px minmax(0,1fr);gap:0;min-height:70vh;background:transparent;position:relative}
+.hrissq-dashboard.is-collapsed{grid-template-columns:0 minmax(0,1fr)}
+.hrissq-dashboard.is-collapsed .hrissq-sidebar{opacity:0;pointer-events:none}
+.hrissq-sidebar{padding:28px 22px;display:flex;flex-direction:column;gap:20px;background:rgba(255,255,255,.82);border-right:1px solid rgba(15,23,42,.08);backdrop-filter:blur(10px);min-height:100%;transition:opacity .25s ease;z-index:30}
+.hrissq-sidebar-header{display:flex;align-items:center;justify-content:space-between;gap:12px}
+.hrissq-sidebar-logo{font-size:18px;font-weight:800;color:var(--brand);letter-spacing:.02em}
+.hrissq-icon-button{display:inline-flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:50%;border:1px solid rgba(15,23,42,.12);background:rgba(255,255,255,.7);color:var(--text);cursor:pointer;transition:background .2s ease,color .2s ease,transform .2s ease}
+.hrissq-icon-button:hover{background:rgba(23,88,135,.08);color:var(--brand);transform:translateY(-1px)}
+.hrissq-sidebar-close{display:none;font-size:20px;line-height:1}
+.hrissq-sidebar-nav{display:flex;flex-direction:column;gap:6px;font-size:14px}
+.hrissq-sidebar-nav a{display:block;padding:10px 14px;border-radius:12px;color:var(--text);background:rgba(255,255,255,.4);border:1px solid rgba(15,23,42,.05);transition:background .2s ease,color .2s ease,transform .2s ease}
+.hrissq-sidebar-nav a:hover{background:rgba(23,88,135,.08);color:var(--brand)}
+.hrissq-sidebar-nav a.is-active{background:var(--brand);color:#fff;border-color:var(--brand);box-shadow:0 12px 30px rgba(23,88,135,.24)}
+.hrissq-sidebar-nav hr{border:none;border-top:1px solid rgba(15,23,42,.08);margin:10px 0}
+.hrissq-sidebar-meta{margin-top:auto;font-size:12px;color:var(--muted)}
+.hrissq-sidebar-overlay{display:none}
+.hrissq-main{display:flex;flex-direction:column;background:transparent}
+.hrissq-topbar{display:flex;align-items:center;justify-content:space-between;gap:18px;padding:24px;border-bottom:1px solid rgba(15,23,42,.08);background:rgba(255,255,255,.85);backdrop-filter:blur(10px)}
+.hrissq-topbar-left{display:flex;align-items:flex-start;gap:18px}
+.hrissq-menu-toggle{margin-top:4px}
+.hrissq-menu-toggle span{width:18px;height:2px;border-radius:999px;background:var(--text);display:block}
+.hrissq-menu-toggle span+span{margin-top:4px}
+.hrissq-page-title{margin:0;font-size:24px;font-weight:800}
+.hrissq-page-subtitle{margin:6px 0 0;color:var(--muted);font-size:14px}
+.hrissq-user{display:flex;align-items:center;gap:16px}
+.hrissq-user-meta{display:flex;flex-direction:column;gap:2px;text-align:right}
+.hrissq-user-name{font-weight:700}
+.hrissq-user-role{font-size:12px;color:var(--muted)}
+.hrissq-main-body{padding:32px 24px 40px;display:flex;flex-direction:column;gap:28px;background:transparent}
+.hrissq-card-grid{display:grid;gap:20px}
+.hrissq-card-grid--3{grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
+.hrissq-card-grid--2{grid-template-columns:repeat(auto-fit,minmax(280px,1fr))}
+.hrissq-card{padding:22px 24px;border-radius:20px;border:1px solid rgba(15,23,42,.08);background:rgba(255,255,255,.92);box-shadow:0 14px 30px rgba(15,23,42,.08);display:flex;flex-direction:column;gap:12px}
+.hrissq-card-title{margin:0;font-size:18px;font-weight:700}
+.hrissq-card-highlight{background:linear-gradient(135deg,rgba(23,88,135,.92),rgba(14,165,233,.92));color:#fff;border-color:rgba(23,88,135,.95);box-shadow:0 18px 38px rgba(23,88,135,.35)}
+.hrissq-card-highlight .hrissq-card-title{color:#fff}
+.hrissq-card-highlight p{color:rgba(255,255,255,.85)}
+.hrissq-card-link{display:inline-flex;align-items:center;gap:6px;font-weight:700;color:inherit;text-decoration:none}
+.hrissq-card-link::after{content:"→";font-size:16px}
+.hrissq-meta-list{display:grid;gap:10px;font-size:14px}
+.hrissq-meta-list div{display:flex;flex-direction:column;gap:2px}
+.hrissq-meta-list dt{font-size:12px;text-transform:uppercase;letter-spacing:.04em;color:var(--muted)}
+.hrissq-meta-list dd{margin:0;font-weight:600;color:var(--text)}
+.hrissq-bullet-list{margin:0;padding-left:18px;display:grid;gap:8px;color:var(--text)}
+.hrissq-bullet-list strong{color:var(--brand)}
+
+@media (max-width:960px){
+  .hrissq-dashboard{grid-template-columns:minmax(0,1fr)}
+  .hrissq-sidebar{position:fixed;inset:0 auto 0 0;height:100vh;width:270px;transform:translateX(-110%);transition:transform .25s ease,box-shadow .25s ease;opacity:1;pointer-events:auto;border-right:1px solid rgba(15,23,42,.12);box-shadow:16px 0 40px rgba(15,23,42,.15)}
+  .hrissq-sidebar.is-open{transform:translateX(0)}
+  .hrissq-sidebar-close{display:inline-flex}
+  .hrissq-sidebar-overlay{position:fixed;inset:0;background:rgba(15,23,42,.45);backdrop-filter:blur(2px);display:none;z-index:20}
+  .hrissq-sidebar-overlay.is-visible{display:block}
+  .hrissq-topbar{padding:20px 18px}
+  .hrissq-topbar-left{align-items:center}
+  .hrissq-menu-toggle{display:inline-flex}
+  .hrissq-user{align-items:flex-end}
+}
+
+@media (max-width:600px){
+  .hrissq-main-body{padding:24px 16px 32px}
+  .hrissq-user{flex-direction:column;align-items:flex-end;gap:10px}
+  .hrissq-user-meta{text-align:right}
+}
 
 /* Modal */
 .modal-backdrop{position:fixed;inset:0;background:rgba(0,0,0,.5);display:flex;align-items:center;justify-content:center;padding:16px;z-index:50}

--- a/assets/app.js
+++ b/assets/app.js
@@ -127,6 +127,101 @@
     });
   }
 
+  // --- DASHBOARD: sidebar toggle ---
+  function bootSidebarToggle() {
+    const layout = document.getElementById('hrissq-dashboard');
+    const sidebar = document.getElementById('hrissq-sidebar');
+    const toggle = document.getElementById('hrissq-sidebar-toggle');
+    if (!layout || !sidebar || !toggle) return;
+
+    const overlay = document.getElementById('hrissq-sidebar-overlay');
+    const closeBtn = document.getElementById('hrissq-sidebar-close');
+    const mq = window.matchMedia('(max-width: 960px)');
+
+    function isMobile() {
+      return mq.matches;
+    }
+
+    function setAria(open) {
+      toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+      sidebar.setAttribute('aria-hidden', open ? 'false' : 'true');
+      if (overlay) {
+        const overlayVisible = isMobile() && open;
+        overlay.setAttribute('aria-hidden', overlayVisible ? 'false' : 'true');
+      }
+    }
+
+    function openMobile() {
+      sidebar.classList.add('is-open');
+      if (overlay) overlay.classList.add('is-visible');
+      setAria(true);
+    }
+
+    function closeMobile() {
+      sidebar.classList.remove('is-open');
+      if (overlay) overlay.classList.remove('is-visible');
+      setAria(false);
+    }
+
+    function toggleDesktop() {
+      const collapsed = layout.classList.toggle('is-collapsed');
+      setAria(!collapsed);
+    }
+
+    function handleChange() {
+      if (isMobile()) {
+        layout.classList.remove('is-collapsed');
+        if (sidebar.classList.contains('is-open')) {
+          setAria(true);
+          if (overlay) overlay.classList.add('is-visible');
+        } else {
+          setAria(false);
+          if (overlay) overlay.classList.remove('is-visible');
+        }
+      } else {
+        sidebar.classList.remove('is-open');
+        if (overlay) overlay.classList.remove('is-visible');
+        const collapsed = layout.classList.contains('is-collapsed');
+        setAria(!collapsed);
+      }
+    }
+
+    toggle.addEventListener('click', function () {
+      if (isMobile()) {
+        if (sidebar.classList.contains('is-open')) {
+          closeMobile();
+        } else {
+          openMobile();
+        }
+      } else {
+        toggleDesktop();
+      }
+    });
+
+    if (closeBtn) {
+      closeBtn.addEventListener('click', function () {
+        if (isMobile()) {
+          closeMobile();
+        } else {
+          layout.classList.add('is-collapsed');
+          setAria(false);
+        }
+      });
+    }
+
+    if (overlay) {
+      overlay.addEventListener('click', closeMobile);
+    }
+
+    if (mq.addEventListener) {
+      mq.addEventListener('change', handleChange);
+    } else if (mq.addListener) {
+      mq.addListener(handleChange);
+    }
+
+    handleChange();
+  }
+
   // --- AUTO LOGOUT (Idle 15 menit, warning 30 detik) ---
   function bootIdleLogout() {
     const backdrop = document.getElementById('hrq-idle-backdrop');
@@ -246,6 +341,7 @@
   document.addEventListener('DOMContentLoaded', function () {
     bootLogin();
     bootLogoutButton();
+    bootSidebarToggle();
     bootIdleLogout();
     bootTrainingForm();
   });

--- a/includes/View.php
+++ b/includes/View.php
@@ -12,7 +12,10 @@ class View {
     ob_start(); ?>
     <div class="hrissq-auth-wrap">
       <div class="auth-card">
-        <h2>Hubungi Kami<br> Sekarang</h2>
+        <div class="auth-header">
+          <h2>Hubungi Kami Sekarang</h2>
+          <p>Masuk dengan NIP dan password untuk mengakses dashboard pegawai.</p>
+        </div>
 
         <form id="hrissq-login-form" class="auth-form">
           <label>NIP <span class="req">*</span></label>
@@ -65,91 +68,132 @@ class View {
     wp_enqueue_script('hrissq');
 
     ob_start(); ?>
-    <div class="hrissq-dashboard">
+    <div class="hrissq-dashboard" id="hrissq-dashboard">
 
       <!-- Sidebar -->
-      <aside class="sidebar">
-        <div class="logo"><span>SQ Pegawai</span></div>
-        <nav>
-          <a href="<?= esc_url(site_url('/'.HRISSQ_DASHBOARD_SLUG)) ?>">Dashboard</a>
+      <aside class="hrissq-sidebar" id="hrissq-sidebar" aria-label="Navigasi utama">
+        <div class="hrissq-sidebar-header">
+          <span class="hrissq-sidebar-logo">SQ Pegawai</span>
+          <button type="button" class="hrissq-icon-button hrissq-sidebar-close" id="hrissq-sidebar-close" aria-label="Tutup menu navigasi">
+            <span aria-hidden="true">×</span>
+          </button>
+        </div>
+        <nav class="hrissq-sidebar-nav">
+          <a class="is-active" href="<?= esc_url(site_url('/'.HRISSQ_DASHBOARD_SLUG)) ?>">Dashboard</a>
           <a href="#">Profil</a>
           <a href="#">Slip Gaji</a>
           <a href="#">Rekap Absensi</a>
           <a href="#">Riwayat Kepegawaian</a>
-          <a href="#">Cuti & Izin</a>
+          <a href="#">Cuti &amp; Izin</a>
           <a href="#">Penilaian Kinerja</a>
-          <a href="#">Tugas & Komunikasi</a>
+          <a href="#">Tugas &amp; Komunikasi</a>
           <a href="#">Administrasi Lain</a>
           <hr>
           <a href="#">Panduan</a>
           <a href="#">Support</a>
         </nav>
+        <div class="hrissq-sidebar-meta">
+          <span>Versi <?= esc_html(HRISSQ_VER) ?></span>
+        </div>
       </aside>
 
+      <div class="hrissq-sidebar-overlay" id="hrissq-sidebar-overlay" aria-hidden="true"></div>
+
       <!-- Main -->
-      <main class="content">
-        <!-- Header -->
-        <header class="topbar">
-          <h2>Dashboard Pegawai</h2>
-          <div class="user-menu">
-            <span class="user-name"><?= esc_html($me->nama) ?></span>
-            <div class="dropdown">
-              <a href="#">Perbarui Profil</a>
-              <a href="#">Ganti Password</a>
-              <a href="#" id="hrissq-logout">Keluar</a>
+      <main class="hrissq-main">
+        <header class="hrissq-topbar">
+          <div class="hrissq-topbar-left">
+            <button type="button" class="hrissq-icon-button hrissq-menu-toggle" id="hrissq-sidebar-toggle" aria-label="Buka menu navigasi" aria-expanded="true">
+              <span></span>
+              <span></span>
+              <span></span>
+            </button>
+            <div>
+              <h1 class="hrissq-page-title">Dashboard Pegawai</h1>
+              <p class="hrissq-page-subtitle">Ringkasan informasi dan tindakan penting untuk akun Anda.</p>
             </div>
+          </div>
+          <div class="hrissq-user">
+            <div class="hrissq-user-meta">
+              <span class="hrissq-user-name"><?= esc_html($me->nama) ?></span>
+              <span class="hrissq-user-role">NIP: <?= esc_html($me->nip ?? '-') ?></span>
+            </div>
+            <button type="button" class="btn-light" id="hrissq-logout">Keluar</button>
           </div>
         </header>
 
-        <!-- Cards -->
-        <section class="cards">
-          <div class="card">
-            <h3>Status Data</h3>
-            <p>Butuh Pembaruan.<br>Lengkapi riwayat pelatihan Anda.</p>
-            <a href="<?= esc_url(site_url('/'.HRISSQ_FORM_SLUG)) ?>">Isi Form Pelatihan →</a>
-          </div>
+        <div class="hrissq-main-body">
+          <section class="hrissq-card-grid hrissq-card-grid--3">
+            <article class="hrissq-card hrissq-card-highlight">
+              <h3 class="hrissq-card-title">Status Data</h3>
+              <p>Butuh pembaruan. Lengkapi riwayat pelatihan Anda untuk memastikan data tetap mutakhir.</p>
+              <a class="hrissq-card-link" href="<?= esc_url(site_url('/'.HRISSQ_FORM_SLUG)) ?>">Isi Form Pelatihan</a>
+            </article>
 
-          <div class="card">
-            <h3>Unit & Jabatan</h3>
-            <p>
-              <?= esc_html($prof->unit ?? $me->unit ?? '-') ?><br>
-              Jabatan: <?= esc_html($prof->jabatan ?? $me->jabatan ?? '-') ?>
-            </p>
-          </div>
+            <article class="hrissq-card">
+              <h3 class="hrissq-card-title">Unit &amp; Jabatan</h3>
+              <dl class="hrissq-meta-list">
+                <div>
+                  <dt>Unit</dt>
+                  <dd><?= esc_html($prof->unit ?? $me->unit ?? '-') ?></dd>
+                </div>
+                <div>
+                  <dt>Jabatan</dt>
+                  <dd><?= esc_html($prof->jabatan ?? $me->jabatan ?? '-') ?></dd>
+                </div>
+              </dl>
+            </article>
 
-          <div class="card">
-            <h3>Profil Ringkas</h3>
-            <?php if ($prof): ?>
+            <article class="hrissq-card">
+              <h3 class="hrissq-card-title">Kontak Utama</h3>
               <p>
-                <b><?= esc_html($prof->nama) ?></b><br>
-                NIP: <?= esc_html($prof->nip) ?><br>
-                TTL: <?= esc_html(($prof->tempat_lahir ?: '-').', '.($prof->tanggal_lahir ?: '-')) ?><br>
-                HP: <?= esc_html($prof->hp ?: '-') ?> • Email: <?= esc_html($prof->email ?: '-') ?><br>
-                Alamat KTP: <?= esc_html($prof->alamat_ktp ?: '-') ?>,
-                <?= esc_html($prof->desa ?: '-') ?>, <?= esc_html($prof->kecamatan ?: '-') ?>,
-                <?= esc_html($prof->kota ?: '-') ?> <?= esc_html($prof->kode_pos ?: '') ?><br>
-                TMT: <?= esc_html($prof->tmt ?: '-') ?>
+                HP: <?= esc_html($prof->hp ?? $me->hp ?? '-') ?><br>
+                Email: <?= esc_html($prof->email ?? $me->email ?? '-') ?>
               </p>
-            <?php else: ?>
-              <p>Belum ada data profil untuk NIP ini. (Coba jalankan import CSV di Tools → HRISSQ Import)</p>
-            <?php endif; ?>
-          </div>
+            </article>
+          </section>
 
-          <div class="card">
-            <h3>Pengumuman</h3>
-            <p>SPMB Dibuka.<br>Cek info terbaru di bawah.</p>
-          </div>
-        </section>
+          <section class="hrissq-card-grid hrissq-card-grid--2">
+            <article class="hrissq-card">
+              <h3 class="hrissq-card-title">Profil Ringkas</h3>
+              <?php if ($prof): ?>
+                <dl class="hrissq-meta-list">
+                  <div>
+                    <dt>Nama</dt>
+                    <dd><?= esc_html($prof->nama) ?></dd>
+                  </div>
+                  <div>
+                    <dt>NIP</dt>
+                    <dd><?= esc_html($prof->nip) ?></dd>
+                  </div>
+                  <div>
+                    <dt>Tempat &amp; Tanggal Lahir</dt>
+                    <dd><?= esc_html(($prof->tempat_lahir ?: '-').', '.($prof->tanggal_lahir ?: '-')) ?></dd>
+                  </div>
+                  <div>
+                    <dt>Alamat</dt>
+                    <dd><?= esc_html($prof->alamat_ktp ?: '-') ?>, <?= esc_html($prof->desa ?: '-') ?>, <?= esc_html($prof->kecamatan ?: '-') ?>, <?= esc_html($prof->kota ?: '-') ?> <?= esc_html($prof->kode_pos ?: '') ?></dd>
+                  </div>
+                  <div>
+                    <dt>TMT</dt>
+                    <dd><?= esc_html($prof->tmt ?: '-') ?></dd>
+                  </div>
+                </dl>
+              <?php else: ?>
+                <p>Belum ada data profil untuk NIP ini. Silakan jalankan import CSV melalui Tools → HRISSQ Import.</p>
+              <?php endif; ?>
+            </article>
 
-        <!-- News / Announcement -->
-        <section class="news">
-          <h3>Berita & Pengumuman</h3>
-          <ul>
-            <li><b>Pembaruan Data Pegawai</b> – Segera isi form profil terbaru.</li>
-            <li><b>SPMB 2026/2027</b> – Pendaftaran telah dibuka.</li>
-            <li><b>Agenda Internal</b> – Training Sabtu pekan ini.</li>
-          </ul>
-        </section>
+            <article class="hrissq-card">
+              <h3 class="hrissq-card-title">Pengumuman</h3>
+              <ul class="hrissq-bullet-list">
+                <li><strong>Pembaruan Data Pegawai</strong> – Segera isi form profil terbaru.</li>
+                <li><strong>SPMB 2026/2027</strong> – Pendaftaran telah dibuka.</li>
+                <li><strong>Agenda Internal</strong> – Training Sabtu pekan ini.</li>
+              </ul>
+            </article>
+          </section>
+        </div>
       </main>
     </div>
 


### PR DESCRIPTION
## Summary
- refresh the login screen with transparent styling that matches the site theme and clearer copy
- rebuild the dashboard layout with a tidy card grid and a collapsible navigation sidebar
- add responsive sidebar toggle behaviour to the front-end script to support desktop and mobile

## Testing
- php -l includes/View.php

------
https://chatgpt.com/codex/tasks/task_e_68dd2ceb5a288323ae38edf3a382f09e