### PR TITLE
Improve HRISSQ glass UI contrast and signed training link

### DIFF
--- a/assets/app.css
+++ b/assets/app.css
@@ -1,112 +1,209 @@
 :root{
   /* Warna tema – gampang diubah */
   --bg:#f5f7fb;
-  --card:#ffffff;
+  --card:rgba(255,255,255,.18);
   --text:#0f172a;
-  --muted:#64748b;
+  --muted:#475569;
   --brand:#175887;       /* biru senada tema situs */
   --brand-2:#0ea5e9;     /* aksen */
-  --ring:rgba(23,88,135,.25);
-  --line:#e2e8f0;
+  --ring:rgba(23,88,135,.16);
+  --line:rgba(23,88,135,.22);
+  --glass-bg:rgba(255,255,255,.38);
+  --glass-soft:rgba(255,255,255,.46);
+  --glass-border:rgba(255,255,255,.62);
+  --glass-dark:rgba(15,23,42,.22);
+  --glass-shadow:0 12px 28px rgba(15,23,42,.16);
+  --font-heading:15px;
+  --font-sub:13px;
+  --font-body:12px;
 }
 
-*{box-sizing:border-box}
-html,body{margin:0;background:var(--bg);color:var(--text);font:14px/1.5 ui-sans-serif,system-ui,Segoe UI,Roboto,Arial}
+#hrissq-app,
+#hrissq-app *{box-sizing:border-box}
 
-a{color:var(--brand);text-decoration:none}
-a:hover{opacity:.9}
+#hrissq-app{
+  background:transparent;
+  color:var(--text);
+  font:var(--font-body)/1.55 ui-sans-serif,system-ui,Segoe UI,Roboto,Arial;
+}
+
+#hrissq-app :where(h1,h2,h3){font-size:var(--font-heading);line-height:1.35;font-weight:700;margin:0;color:var(--text)}
+#hrissq-app :where(h4,h5,h6){font-size:var(--font-sub);line-height:1.4;font-weight:600;margin:0;color:var(--text)}
+#hrissq-app p{margin:0 0 10px;font-size:var(--font-body)}
+#hrissq-app :where(ul,ol){margin:0 0 10px;padding-left:18px}
+#hrissq-app :where(li,dt,dd,label,input,button,select,textarea){font-size:var(--font-body)}
+#hrissq-app :where(button,input,select,textarea){font-family:inherit;color:inherit}
+
+#hrissq-app a{color:var(--brand);text-decoration:none}
+#hrissq-app a:hover{opacity:.9}
 
 /* Util */
-.hrq-wrap{max-width:1100px;margin:24px auto;padding:0 16px}
-.hrq-center{display:grid;place-items:center;min-height:70vh}
-.hrq-card{background:var(--card);border-radius:14px;box-shadow:0 8px 24px rgba(2,6,23,.06);padding:18px}
-.hrq-title{margin:0 0 8px;font-size:20px}
-.hrq-hint{color:var(--muted);font-size:12px;margin-bottom:12px}
-.hrq-input{width:100%;padding:10px 12px;border:1px solid var(--line);border-radius:10px;outline:none}
-.hrq-input:focus{border-color:var(--brand);box-shadow:0 0 0 4px var(--ring)}
-.hrq-btn{display:inline-block;background:var(--brand);color:#fff;border:none;border-radius:10px;padding:10px 14px;font-weight:700;cursor:pointer}
-.hrq-btn:hover{filter:brightness(1.02)}
-.hrq-status{margin-top:10px;font-size:12px}
-.hrq-status.err{color:#b91c1c}
-.hrq-status.ok{color:#065f46}
-.hrq-link{color:var(--brand-2);font-weight:600}
+#hrissq-app .hrq-wrap{max-width:1100px;margin:24px auto;padding:0 16px}
+#hrissq-app .hrq-center{display:grid;place-items:center;min-height:70vh}
+#hrissq-app .hrq-card{background:var(--glass-soft);border-radius:10px;box-shadow:var(--glass-shadow);padding:12px;border:1px solid var(--glass-border);backdrop-filter:blur(14px)}
+#hrissq-app .hrq-title{margin:0 0 8px;font-size:20px}
+#hrissq-app .hrq-hint{color:var(--muted);font-size:12px;margin-bottom:12px}
+#hrissq-app .hrq-input{width:100%;padding:10px 12px;border:1px solid rgba(23,88,135,.24);border-radius:10px;outline:none;background:rgba(255,255,255,.78);backdrop-filter:blur(14px)}
+#hrissq-app .hrq-input:focus{border-color:var(--brand);box-shadow:0 0 0 3px var(--ring);background:rgba(255,255,255,.92)}
+#hrissq-app .hrq-btn{display:inline-block;background:linear-gradient(135deg,rgba(23,88,135,.78),rgba(14,165,233,.6));color:#fff;border:1px solid rgba(23,88,135,.35);border-radius:10px;padding:10px 14px;font-weight:700;cursor:pointer;transition:filter .2s ease,transform .2s ease,box-shadow .2s ease}
+#hrissq-app .hrq-btn:hover{filter:brightness(1.05);transform:translateY(-1px);box-shadow:0 10px 22px rgba(23,88,135,.18)}
+#hrissq-app .hrq-status{margin-top:10px;font-size:12px}
+#hrissq-app .hrq-status.err{color:#b91c1c}
+#hrissq-app .hrq-status.ok{color:#065f46}
+#hrissq-app .hrq-link{color:var(--brand-2);font-weight:600}
 
 /* Login */
-.hrq-login{max-width:420px;width:100%}
-.hrq-login label{display:block;margin:10px 0 6px;font-weight:600}
-.hrq-input-pass{position:relative}
-.hrq-see{position:absolute;right:6px;top:50%;transform:translateY(-50%);border:1px solid var(--line);background:#f1f5f9;border-radius:8px;font-size:12px;padding:4px 8px;cursor:pointer}
+#hrissq-app .hrq-login{max-width:420px;width:100%}
+#hrissq-app .hrq-login label{display:block;margin:10px 0 6px;font-weight:600}
+#hrissq-app .hrq-input-pass{position:relative}
+#hrissq-app .hrq-see{position:absolute;right:6px;top:50%;transform:translateY(-50%);border:1px solid rgba(23,88,135,.28);background:rgba(255,255,255,.55);border-radius:8px;font-size:12px;padding:4px 8px;cursor:pointer;color:var(--text)}
 
 /* Layout */
-.hrq-layout{display:grid;grid-template-columns:260px 1fr;min-height:100vh}
-@media (max-width:960px){.hrq-layout{grid-template-columns:1fr}}
-.hrq-sidebar{background:#0d2844;color:#e5eef7;position:sticky;top:0;height:100vh;padding:12px;display:flex;flex-direction:column;gap:8px}
-@media (max-width:960px){.hrq-sidebar{position:fixed;left:0;top:0;bottom:0;transform:translateX(-100%);transition:transform .25s ease;z-index:40;width:260px}}
-.hrq-sidebar.show{transform:translateX(0)}
-.hrq-brand{display:flex;align-items:center;gap:10px;padding:6px 8px 12px;border-bottom:1px solid rgba(255,255,255,.08);margin-bottom:8px}
-.hrq-burger{background:#0b2137;color:#cde6ff;border:1px solid rgba(255,255,255,.1);border-radius:10px;padding:6px 10px;cursor:pointer}
-.hrq-menu a{display:block;color:#e5eef7;padding:10px 12px;border-radius:10px}
-.hrq-menu a:hover,.hrq-menu a.active{background:rgba(255,255,255,.08)}
-.hrq-section{padding:12px 10px;color:#8fb4d6;font-size:12px;text-transform:uppercase;letter-spacing:.04em}
+#hrissq-app .hrq-layout{display:grid;grid-template-columns:260px 1fr;min-height:100vh}
+@media (max-width:960px){#hrissq-app .hrq-layout{grid-template-columns:1fr}}
+#hrissq-app .hrq-sidebar{background:var(--glass-bg);color:var(--text);position:sticky;top:0;height:100vh;padding:12px;display:flex;flex-direction:column;gap:8px;border-right:1px solid var(--glass-border);backdrop-filter:blur(16px);box-shadow:6px 0 24px rgba(15,23,42,.12)}
+@media (max-width:960px){#hrissq-app .hrq-sidebar{position:fixed;left:0;top:0;bottom:0;transform:translateX(-100%);transition:transform .25s ease;z-index:40;width:260px}}
+#hrissq-app .hrq-sidebar.show{transform:translateX(0)}
+#hrissq-app .hrq-brand{display:flex;align-items:center;gap:10px;padding:6px 8px 12px;border-bottom:1px solid rgba(255,255,255,.35);margin-bottom:8px}
+#hrissq-app .hrq-burger{background:rgba(255,255,255,.45);color:var(--text);border:1px solid rgba(23,88,135,.28);border-radius:10px;padding:6px 10px;cursor:pointer;backdrop-filter:blur(12px)}
+#hrissq-app .hrq-menu a{display:block;color:var(--text);padding:10px 12px;border-radius:10px;transition:background .2s ease,transform .2s ease}
+#hrissq-app .hrq-menu a:hover,#hrissq-app .hrq-menu a.active{background:rgba(255,255,255,.55);transform:translateY(-1px)}
+#hrissq-app .hrq-section{padding:12px 10px;color:#8fb4d6;font-size:12px;text-transform:uppercase;letter-spacing:.04em}
 
-.hrq-main{display:flex;flex-direction:column}
-.hrq-topbar{background:var(--card);display:flex;justify-content:space-between;align-items:center;padding:12px 16px;border-bottom:1px solid var(--line);position:sticky;top:0;z-index:30}
-.hrq-search{flex:1;max-width:520px}
-.hrq-user{display:flex;align-items:center;gap:12px;position:relative}
-.hrq-user-name{display:flex;flex-direction:column;line-height:1.2}
-.hrq-avatar{width:36px;height:36px;border-radius:50%;border:none;background:var(--brand);color:#fff;font-weight:800;cursor:pointer}
-.hrq-dropdown{position:absolute;right:0;top:46px;background:#fff;border:1px solid var(--line);border-radius:12px;box-shadow:0 12px 22px rgba(2,6,23,.1);overflow:hidden;min-width:180px}
-.hrq-dropdown a,.hrq-dropdown button{display:block;width:100%;text-align:left;padding:10px 12px;background:#fff;border:none;color:var(--text);cursor:pointer}
-.hrq-dropdown a:hover,.hrq-dropdown button:hover{background:#f8fafc}
+#hrissq-app .hrq-main{display:flex;flex-direction:column}
+#hrissq-app .hrq-topbar{background:var(--glass-bg);display:flex;justify-content:space-between;align-items:center;padding:8px 12px;border-bottom:1px solid var(--glass-border);position:sticky;top:0;z-index:30;backdrop-filter:blur(18px);box-shadow:0 10px 22px rgba(15,23,42,.12)}
+#hrissq-app .hrq-search{flex:1;max-width:520px}
+#hrissq-app .hrq-user{display:flex;align-items:center;gap:12px;position:relative}
+#hrissq-app .hrq-user-name{display:flex;flex-direction:column;line-height:1.2}
+#hrissq-app .hrq-avatar{width:36px;height:36px;border-radius:50%;border:none;background:var(--brand);color:#fff;font-weight:800;cursor:pointer}
+#hrissq-app .hrq-dropdown{position:absolute;right:0;top:46px;background:var(--glass-soft);border:1px solid var(--glass-border);border-radius:10px;box-shadow:0 12px 26px rgba(2,6,23,.14);overflow:hidden;min-width:180px;backdrop-filter:blur(18px)}
+#hrissq-app .hrq-dropdown a,#hrissq-app .hrq-dropdown button{display:block;width:100%;text-align:left;padding:8px 10px;background:transparent;border:none;color:var(--text);cursor:pointer}
+#hrissq-app .hrq-dropdown a:hover,#hrissq-app .hrq-dropdown button:hover{background:rgba(255,255,255,.55)}
 
-.hrq-content{padding:18px}
-.hrq-page-title{margin:8px 0 16px}
-.hrq-grid{display:grid;gap:14px}
-.hrq-grid-3{grid-template-columns:repeat(3,minmax(0,1fr))}
-@media (max-width:960px){.hrq-grid-3{grid-template-columns:1fr}}
-.hrq-stat .hrq-stat-title{color:var(--muted);font-size:12px;margin-bottom:6px}
-.hrq-stat .hrq-stat-value{font-size:22px;font-weight:800;margin-bottom:4px}
-.hrq-stat .hrq-stat-desc{color:var(--muted);font-size:12px;margin-bottom:8px}
-.hrq-section-title{margin:20px 0 8px;font-size:16px}
+#hrissq-app .hrq-content{padding:18px}
+#hrissq-app .hrq-page-title{margin:8px 0 16px}
+#hrissq-app .hrq-grid{display:grid;gap:14px}
+#hrissq-app .hrq-grid-3{grid-template-columns:repeat(3,minmax(0,1fr))}
+@media (max-width:960px){#hrissq-app .hrq-grid-3{grid-template-columns:1fr}}
+#hrissq-app .hrq-stat .hrq-stat-title{color:var(--muted);font-size:12px;margin-bottom:6px}
+#hrissq-app .hrq-stat .hrq-stat-value{font-size:22px;font-weight:800;margin-bottom:4px}
+#hrissq-app .hrq-stat .hrq-stat-desc{color:var(--muted);font-size:12px;margin-bottom:8px}
+#hrissq-app .hrq-section-title{margin:20px 0 8px;font-size:16px}
 
 /* Form */
-.hrq-form label{display:block;margin:10px 0 6px;font-weight:600}
+#hrissq-app .hrq-form label{display:block;margin:10px 0 6px;font-weight:600}
 
 /* ==== Auth new look ==== */
-.hrissq-auth-wrap{min-height:70vh;display:grid;place-items:center;padding:24px;background:#f3f4f6}
-.auth-card{width:100%;max-width:420px;background:#0f4a43; /* hijau SQ tua sebagai border */
-  border-radius:24px;padding:14px}
-.auth-card .auth-form, .auth-card h2{
-  background:#fff;border-radius:18px;padding:20px
+#hrissq-app .hrissq-auth-wrap{display:flex;align-items:center;justify-content:center;padding:48px 12px;background:transparent}
+#hrissq-app .auth-card{width:100%;max-width:240px;padding:16px 18px;border-radius:14px;border:1px solid var(--glass-border);background:var(--glass-bg);box-shadow:var(--glass-shadow);backdrop-filter:blur(18px)}
+#hrissq-app .auth-header{text-align:center;margin-bottom:12px}
+#hrissq-app .auth-header h2{font-size:var(--font-heading);font-weight:700}
+#hrissq-app .auth-form{display:flex;flex-direction:column;gap:8px}
+#hrissq-app .auth-form label{display:block;font-weight:600;color:var(--text)}
+#hrissq-app .auth-form input{width:100%;padding:7px 10px;border:1px solid rgba(23,88,135,.28);border-radius:9px;background:rgba(255,255,255,.78);color:var(--text);backdrop-filter:blur(16px)}
+#hrissq-app .auth-form input::placeholder{color:rgba(71,85,105,.7)}
+#hrissq-app .auth-form input:focus{border-color:var(--brand);box-shadow:0 0 0 2px var(--ring);outline:none;background:rgba(255,255,255,.9)}
+#hrissq-app .req{color:#ef4444}
+#hrissq-app .pw-row{display:flex;gap:6px;align-items:center}
+#hrissq-app .pw-row input{flex:1 1 auto}
+#hrissq-app .pw-row .eye{flex:0 0 auto;border:1px solid rgba(23,88,135,.28);background:rgba(255,255,255,.75);color:var(--text);padding:6px 10px;border-radius:9px;cursor:pointer;font-weight:600;backdrop-filter:blur(12px)}
+#hrissq-app .pw-row .eye:hover{background:rgba(255,255,255,.88)}
+#hrissq-app .btn-primary{background:linear-gradient(135deg,rgba(23,88,135,.78),rgba(14,165,233,.6));color:#fff;border:1px solid rgba(23,88,135,.35);border-radius:10px;padding:8px 14px;font-weight:700;cursor:pointer;transition:filter .2s ease,transform .2s ease,box-shadow .2s ease}
+#hrissq-app .btn-primary:hover{filter:brightness(1.05);transform:translateY(-1px);box-shadow:0 8px 20px rgba(23,88,135,.22)}
+#hrissq-app .auth-form .btn-primary{width:100%;margin-top:4px}
+#hrissq-app .btn-light{background:rgba(255,255,255,.6);color:var(--text);border:1px solid rgba(148,163,184,.45);border-radius:9px;padding:8px 14px;cursor:pointer;font-weight:600;backdrop-filter:blur(10px);transition:filter .2s ease,transform .2s ease}
+#hrissq-app .btn-light:hover{filter:brightness(1.02);transform:translateY(-1px)}
+#hrissq-app .link-forgot{margin-top:2px;background:none;border:none;color:var(--brand-2);font-weight:600;font-size:var(--font-body);cursor:pointer;text-align:center}
+#hrissq-app .msg{margin-top:4px;font-size:var(--font-body);color:#b91c1c;min-height:14px}
+#hrissq-app .msg.ok{color:#065f46}
+
+/* ==== Dashboard layout ==== */
+#hrissq-app .hrissq-dashboard{display:grid;grid-template-columns:180px minmax(0,1fr);gap:0;min-height:70vh;background:transparent;position:relative}
+#hrissq-app .hrissq-dashboard.is-collapsed{grid-template-columns:0 minmax(0,1fr)}
+#hrissq-app .hrissq-dashboard.is-collapsed .hrissq-sidebar{opacity:0;pointer-events:none}
+#hrissq-app .hrissq-sidebar{padding:12px 10px;display:flex;flex-direction:column;gap:10px;background:var(--glass-bg);border-right:1px solid var(--glass-border);backdrop-filter:blur(18px);min-height:100%;transition:opacity .25s ease;z-index:30;box-shadow:6px 0 24px rgba(15,23,42,.14)}
+#hrissq-app .hrissq-sidebar-header{display:flex;align-items:center;justify-content:space-between;gap:8px}
+#hrissq-app .hrissq-sidebar-logo{font-size:var(--font-sub);font-weight:700;color:var(--brand);letter-spacing:.08em;text-transform:uppercase}
+#hrissq-app .hrissq-icon-button{display:inline-flex;align-items:center;justify-content:center;width:28px;height:28px;border-radius:50%;border:1px solid rgba(23,88,135,.3);background:rgba(255,255,255,.7);color:var(--text);cursor:pointer;transition:background .2s ease,color .2s ease,transform .2s ease;backdrop-filter:blur(14px)}
+#hrissq-app .hrissq-icon-button:hover{background:rgba(255,255,255,.88);color:var(--brand);transform:translateY(-1px)}
+#hrissq-app .hrissq-sidebar-close{display:none;font-size:20px;line-height:1}
+#hrissq-app .hrissq-sidebar-nav{display:flex;flex-direction:column;gap:4px;font-size:11px}
+#hrissq-app .hrissq-sidebar-nav a{display:block;padding:7px 9px;border-radius:9px;color:var(--text);background:rgba(255,255,255,.55);border:1px solid rgba(23,88,135,.18);transition:background .2s ease,color .2s ease,transform .2s ease;backdrop-filter:blur(12px)}
+#hrissq-app .hrissq-sidebar-nav a:hover{background:rgba(255,255,255,.75);color:var(--brand);transform:translateY(-1px)}
+#hrissq-app .hrissq-sidebar-nav a.is-active{background:linear-gradient(135deg,rgba(23,88,135,.55),rgba(14,165,233,.4));color:#fff;border-color:rgba(23,88,135,.45);box-shadow:0 10px 22px rgba(23,88,135,.22)}
+#hrissq-app .hrissq-sidebar-nav hr{border:none;border-top:1px solid rgba(23,88,135,.16);margin:10px 0}
+#hrissq-app .hrissq-sidebar-meta{margin-top:auto;font-size:10px;color:rgba(71,85,105,.7)}
+#hrissq-app .hrissq-sidebar-overlay{display:none}
+#hrissq-app .hrissq-main{display:flex;flex-direction:column;background:transparent}
+#hrissq-app .hrissq-topbar{display:flex;align-items:center;justify-content:space-between;gap:10px;padding:10px 12px;border-bottom:1px solid var(--glass-border);background:var(--glass-bg);backdrop-filter:blur(18px);box-shadow:0 12px 26px rgba(15,23,42,.14)}
+#hrissq-app .hrissq-topbar-left{display:flex;align-items:flex-start;gap:8px}
+#hrissq-app .hrissq-menu-toggle{margin-top:0;display:inline-flex;align-items:center;justify-content:center;gap:3px;padding:5px 6px;border-radius:9px;border:1px solid rgba(23,88,135,.28);background:rgba(255,255,255,.6);transition:background .2s ease,transform .2s ease}
+#hrissq-app .hrissq-menu-toggle span{width:2px;height:12px;border-radius:999px;background:var(--text);transition:all .2s ease}
+#hrissq-app .hrissq-menu-toggle[aria-expanded="true"] span{width:3px;height:3px;border-radius:50%}
+#hrissq-app .hrissq-menu-toggle:hover{background:rgba(255,255,255,.16);transform:translateY(-1px)}
+#hrissq-app .hrissq-page-title{font-size:var(--font-heading);font-weight:700;letter-spacing:.02em}
+#hrissq-app .hrissq-page-subtitle{margin:4px 0 0;color:var(--muted);font-size:var(--font-sub)}
+#hrissq-app .hrissq-user{display:flex;align-items:center;gap:8px}
+#hrissq-app .hrissq-user-meta{display:flex;flex-direction:column;gap:1px;text-align:right}
+#hrissq-app .hrissq-user-name{font-weight:700;font-size:var(--font-sub)}
+#hrissq-app .hrissq-user-role{font-size:var(--font-body);color:var(--muted)}
+#hrissq-app .hrissq-main-body{padding:16px 14px 20px;display:flex;flex-direction:column;gap:12px;background:transparent}
+#hrissq-app .hrissq-card-grid{display:grid;gap:10px}
+#hrissq-app .hrissq-card-grid--3{grid-template-columns:repeat(auto-fit,minmax(180px,1fr))}
+#hrissq-app .hrissq-card-grid--2{grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
+#hrissq-app .hrissq-card{padding:10px 12px;border-radius:12px;border:1px solid var(--glass-border);background:var(--glass-soft);box-shadow:0 8px 20px rgba(15,23,42,.12);display:flex;flex-direction:column;gap:6px;backdrop-filter:blur(16px)}
+#hrissq-app .hrissq-card-title{font-size:var(--font-heading);font-weight:600;letter-spacing:.01em;margin-bottom:2px}
+#hrissq-app .hrissq-card p:last-child{margin-bottom:0}
+#hrissq-app .hrissq-card-link{display:inline-flex;align-items:center;gap:4px;font-weight:600;color:inherit;text-decoration:none;transition:transform .2s ease}
+#hrissq-app .hrissq-card-link::after{content:"→";font-size:11px;transition:transform .2s ease}
+#hrissq-app .hrissq-card-link:hover{transform:translateX(2px)}
+#hrissq-app .hrissq-card-link:hover::after{transform:translateX(3px)}
+#hrissq-app .hrissq-meta-list{display:grid;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));gap:6px 16px;align-items:start}
+#hrissq-app .hrissq-meta-list div{display:flex;flex-direction:column;gap:2px}
+#hrissq-app .hrissq-meta-list dt{text-transform:uppercase;letter-spacing:.04em;color:rgba(71,85,105,.9)}
+#hrissq-app .hrissq-meta-list dd{margin:0;font-weight:600;color:var(--text)}
+#hrissq-app .hrissq-bullet-list{margin:0;padding-left:14px;display:grid;gap:6px;color:var(--text);font-size:var(--font-body)}
+#hrissq-app .hrissq-bullet-list strong{color:var(--brand)}
+#hrissq-app .hrissq-bullet-list a{color:var(--brand);font-weight:600;text-decoration:none;border-bottom:1px solid rgba(23,88,135,.2);padding-bottom:1px}
+#hrissq-app .hrissq-bullet-list a:hover{opacity:.85}
+
+@media (max-width:960px){
+  #hrissq-app .hrissq-dashboard{grid-template-columns:minmax(0,1fr)}
+  #hrissq-app .hrissq-sidebar{position:fixed;inset:0 auto 0 0;height:100vh;width:200px;transform:translateX(-110%);transition:transform .25s ease,box-shadow .25s ease;opacity:1;pointer-events:auto;border-right:1px solid var(--glass-border);box-shadow:18px 0 40px rgba(15,23,42,.2)}
+  #hrissq-app .hrissq-sidebar.is-open{transform:translateX(0)}
+  #hrissq-app .hrissq-sidebar-close{display:inline-flex}
+  #hrissq-app .hrissq-sidebar-overlay{position:fixed;inset:0;background:rgba(15,23,42,.45);backdrop-filter:blur(4px);display:none;z-index:20}
+  #hrissq-app .hrissq-sidebar-overlay.is-visible{display:block}
+  #hrissq-app .hrissq-topbar{padding:10px 12px;background:var(--glass-bg)}
+  #hrissq-app .hrissq-topbar-left{align-items:center}
+  #hrissq-app .hrissq-menu-toggle{display:inline-flex}
+  #hrissq-app .hrissq-user{align-items:flex-end}
 }
-.auth-card h2{margin:0 0 12px;text-align:center;font-size:28px;line-height:1.1;font-weight:800}
-.auth-form label{display:block;margin:10px 0 6px;color:#111827;font-weight:600}
-.auth-form input{width:100%;padding:12px 14px;border:1px solid #e5e7eb;border-radius:12px;font-size:14px}
-.req{color:#ef4444}
-.pw-row{display:flex;gap:8px;align-items:center}
-.pw-row .eye{white-space:nowrap;border:1px solid #e5e7eb;background:#f8fafc;color:#334155;padding:10px 12px;border-radius:10px;cursor:pointer}
-.btn-primary{width:100%;margin-top:14px;background:#0f766e;color:#fff;border:none;border-radius:12px;padding:12px 16px;font-weight:800;cursor:pointer}
-.btn-light{background:#e5e7eb;color:#111827;border:none;border-radius:10px;padding:10px 14px;cursor:pointer}
-.link-forgot{margin-top:10px;background:none;border:none;color:#0ea5e9;font-weight:700;cursor:pointer}
-.msg{margin-top:8px;font-size:13px;color:#b91c1c}
-.msg.ok{color:#065f46}
+
+@media (max-width:600px){
+  #hrissq-app .hrissq-main-body{padding:14px 12px 18px}
+  #hrissq-app .hrissq-user{flex-direction:column;align-items:flex-end;gap:10px}
+  #hrissq-app .hrissq-user-meta{text-align:right}
+}
 
 /* Modal */
-.modal-backdrop{position:fixed;inset:0;background:rgba(0,0,0,.5);display:flex;align-items:center;justify-content:center;padding:16px;z-index:50}
-.modal{background:#fff;border-radius:16px;max-width:460px;width:100%;padding:18px}
-.modal h3{margin:0 0 8px;font-size:20px}
-.modal .modal-actions{display:flex;gap:8px;justify-content:flex-end;margin-top:12px}
-.modal input{width:100%;padding:12px 14px;border:1px solid #e5e7eb;border-radius:10px}
-.modal-msg{margin-top:8px;font-size:13px}
+#hrissq-app .modal-backdrop{position:fixed;inset:0;background:rgba(0,0,0,.5);display:flex;align-items:center;justify-content:center;padding:16px;z-index:50}
+#hrissq-app .modal{background:var(--glass-bg);border-radius:12px;max-width:300px;width:100%;padding:14px;box-shadow:0 14px 30px rgba(15,23,42,.15);border:1px solid var(--glass-border);backdrop-filter:blur(18px)}
+#hrissq-app .modal h3{font-size:var(--font-heading)}
+#hrissq-app .modal .modal-actions{display:flex;gap:5px;justify-content:flex-end;margin-top:8px}
+#hrissq-app .modal input{width:100%;padding:7px 10px;border:1px solid rgba(23,88,135,.28);border-radius:9px;background:rgba(255,255,255,.8)}
+#hrissq-app .modal-msg{margin-top:4px}
 
 /* Training Form */
-.hrissq-form-wrap{max-width:680px;margin:30px auto;padding:24px;background:var(--card);border-radius:16px;box-shadow:0 8px 24px rgba(2,6,23,.06)}
-.hrissq-form-wrap h2{margin:0 0 8px;font-size:24px;font-weight:800}
-.hrissq-form-wrap > p{color:var(--muted);margin-bottom:18px}
-.training-form .form-group{margin-bottom:14px}
-.training-form label{display:block;margin-bottom:6px;font-weight:600}
-.training-form input,.training-form select{width:100%;padding:12px 14px;border:1px solid var(--line);border-radius:10px;font-size:14px}
-.training-form input:focus,.training-form select:focus{outline:none;border-color:var(--brand);box-shadow:0 0 0 4px var(--ring)}
-.training-form small{display:block;margin-top:4px;color:var(--muted);font-size:12px}
-.training-form .btn-primary{display:inline-block;background:var(--brand);color:#fff;border:none;border-radius:10px;padding:12px 20px;font-weight:700;cursor:pointer;margin-right:8px}
-.training-form .btn-light{display:inline-block;background:#e5e7eb;color:#334155;border:none;border-radius:10px;padding:12px 20px;font-weight:600;cursor:pointer;text-decoration:none}
+#hrissq-app .hrissq-form-wrap{max-width:420px;margin:20px auto;padding:16px;background:var(--glass-bg);border-radius:12px;box-shadow:0 12px 28px rgba(15,23,42,.14);backdrop-filter:blur(18px);border:1px solid var(--glass-border)}
+#hrissq-app .hrissq-form-wrap h2{margin:0 0 4px;font-size:var(--font-heading);font-weight:600}
+#hrissq-app .hrissq-form-wrap > p{color:var(--muted);margin-bottom:10px}
+#hrissq-app .training-form .form-group{margin-bottom:10px}
+#hrissq-app .training-form label{display:block;margin-bottom:3px;font-weight:600;text-transform:uppercase;letter-spacing:.04em}
+#hrissq-app .training-form input,#hrissq-app .training-form select{width:100%;padding:7px 10px;border:1px solid rgba(23,88,135,.28);border-radius:9px;background:rgba(255,255,255,.78);backdrop-filter:blur(14px)}
+#hrissq-app .training-form input:focus,#hrissq-app .training-form select:focus{outline:none;border-color:var(--brand);box-shadow:0 0 0 2px var(--ring);background:rgba(255,255,255,.92)}
+#hrissq-app .training-form small{display:block;margin-top:2px;color:var(--muted);font-size:10px}
+#hrissq-app .training-form .btn-primary{display:inline-block;background:linear-gradient(135deg,rgba(23,88,135,.78),rgba(14,165,233,.6));color:#fff;border:1px solid rgba(23,88,135,.35);border-radius:10px;padding:8px 16px;font-weight:700;cursor:pointer;margin-right:4px;transition:filter .2s ease,transform .2s ease,box-shadow .2s ease}
+#hrissq-app .training-form .btn-primary:hover{filter:brightness(1.05);transform:translateY(-1px);box-shadow:0 8px 20px rgba(23,88,135,.2)}
+#hrissq-app .training-form .btn-light{display:inline-block;background:rgba(255,255,255,.65);color:#334155;border:1px solid rgba(148,163,184,.45);border-radius:9px;padding:8px 16px;font-weight:600;cursor:pointer;text-decoration:none;backdrop-filter:blur(10px);transition:filter .2s ease,transform .2s ease}
+#hrissq-app .training-form .btn-light:hover{filter:brightness(1.02);transform:translateY(-1px)}

--- a/assets/app.js
+++ b/assets/app.js
@@ -52,7 +52,7 @@
 
       const nip = (form.nip.value || '').trim();
       const pwv = (form.pw.value || '').trim();
-      if (!nip || !pwv) { msg.textContent = 'NIP & Password wajib diisi.'; return; }
+      if (!nip || !pwv) { msg.textContent = 'Akun & Pasword wajib diisi.'; return; }
 
       ajax('hrissq_login', { nip, pw: pwv })
         .then(res => {
@@ -86,7 +86,7 @@
       cancelBtn && (cancelBtn.onclick = () => { backdrop.style.display = 'none'; });
       sendBtn && (sendBtn.onclick = () => {
         const nip = (npInput.value || '').trim();
-        if (!nip) { fMsg.textContent = 'NIP wajib diisi.'; return; }
+        if (!nip) { fMsg.textContent = 'Akun wajib diisi.'; return; }
         fMsg.textContent = 'Mengirim permintaan…';
 
         // NOTE: pastikan endpoint hrissq_forgot sudah ada di Api.php
@@ -118,13 +118,113 @@
       btn.disabled = true;
       const old = btn.textContent;
       btn.textContent = 'Keluar…';
+      const redirectToLogin = () => {
+        const slug = (window.HRISSQ && HRISSQ.loginSlug) ? HRISSQ.loginSlug.replace(/^\/+/, '') : 'masuk';
+        window.location.href = '/' + slug.replace(/\/+$/, '') + '/';
+      };
       ajax('hrissq_logout', {})
+        .then(redirectToLogin)
+        .catch(redirectToLogin)
         .finally(() => {
-          const slug = (window.HRISSQ && HRISSQ.loginSlug) ? HRISSQ.loginSlug.replace(/^\/+/, '') : 'masuk';
-          const to = '/' + slug + (window.location.pathname.endsWith('/') ? '' : '/');
-          window.location.href = to;
+          btn.textContent = old;
+          btn.disabled = false;
         });
     });
+  }
+
+  // --- DASHBOARD: sidebar toggle ---
+  function bootSidebarToggle() {
+    const layout = document.getElementById('hrissq-dashboard');
+    const sidebar = document.getElementById('hrissq-sidebar');
+    const toggle = document.getElementById('hrissq-sidebar-toggle');
+    if (!layout || !sidebar || !toggle) return;
+
+    const overlay = document.getElementById('hrissq-sidebar-overlay');
+    const closeBtn = document.getElementById('hrissq-sidebar-close');
+    const mq = window.matchMedia('(max-width: 960px)');
+
+    function isMobile() {
+      return mq.matches;
+    }
+
+    function setAria(open) {
+      toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+      sidebar.setAttribute('aria-hidden', open ? 'false' : 'true');
+      if (overlay) {
+        const overlayVisible = isMobile() && open;
+        overlay.setAttribute('aria-hidden', overlayVisible ? 'false' : 'true');
+      }
+    }
+
+    function openMobile() {
+      sidebar.classList.add('is-open');
+      if (overlay) overlay.classList.add('is-visible');
+      setAria(true);
+    }
+
+    function closeMobile() {
+      sidebar.classList.remove('is-open');
+      if (overlay) overlay.classList.remove('is-visible');
+      setAria(false);
+    }
+
+    function toggleDesktop() {
+      const collapsed = layout.classList.toggle('is-collapsed');
+      setAria(!collapsed);
+    }
+
+    function handleChange() {
+      if (isMobile()) {
+        layout.classList.remove('is-collapsed');
+        if (sidebar.classList.contains('is-open')) {
+          setAria(true);
+          if (overlay) overlay.classList.add('is-visible');
+        } else {
+          setAria(false);
+          if (overlay) overlay.classList.remove('is-visible');
+        }
+      } else {
+        sidebar.classList.remove('is-open');
+        if (overlay) overlay.classList.remove('is-visible');
+        const collapsed = layout.classList.contains('is-collapsed');
+        setAria(!collapsed);
+      }
+    }
+
+    toggle.addEventListener('click', function () {
+      if (isMobile()) {
+        if (sidebar.classList.contains('is-open')) {
+          closeMobile();
+        } else {
+          openMobile();
+        }
+      } else {
+        toggleDesktop();
+      }
+    });
+
+    if (closeBtn) {
+      closeBtn.addEventListener('click', function () {
+        if (isMobile()) {
+          closeMobile();
+        } else {
+          layout.classList.add('is-collapsed');
+          setAria(false);
+        }
+      });
+    }
+
+    if (overlay) {
+      overlay.addEventListener('click', closeMobile);
+    }
+
+    if (mq.addEventListener) {
+      mq.addEventListener('change', handleChange);
+    } else if (mq.addListener) {
+      mq.addListener(handleChange);
+    }
+
+    handleChange();
   }
 
   // --- AUTO LOGOUT (Idle 15 menit, warning 30 detik) ---
@@ -169,7 +269,7 @@
     function doLogout() {
       ajax('hrissq_logout', {}).finally(() => {
         const slug = (window.HRISSQ && HRISSQ.loginSlug) ? HRISSQ.loginSlug.replace(/^\/+/, '') : 'masuk';
-        window.location.href = '/' + slug + '/';
+        window.location.href = '/' + slug.replace(/\/+$/, '') + '/';
       });
     }
 
@@ -229,7 +329,15 @@
             }, 1500);
           } else {
             msgEl.className = 'msg error';
-            msgEl.textContent = (res && res.msg) ? res.msg : 'Gagal menyimpan data.';
+            if (res && res.msg === 'Unauthorized') {
+              msgEl.textContent = 'Sesi Anda berakhir. Silakan login kembali.';
+              setTimeout(() => {
+                const slug = (window.HRISSQ && HRISSQ.loginSlug) ? HRISSQ.loginSlug.replace(/^\/+/, '') : 'masuk';
+                window.location.href = '/' + slug.replace(/\/+$/, '') + '/';
+              }, 1200);
+            } else {
+              msgEl.textContent = (res && res.msg) ? res.msg : 'Gagal menyimpan data.';
+            }
           }
         })
         .catch(err => {
@@ -246,6 +354,7 @@
   document.addEventListener('DOMContentLoaded', function () {
     bootLogin();
     bootLogoutButton();
+    bootSidebarToggle();
     bootIdleLogout();
     bootTrainingForm();
   });

--- a/docs/SETUP-GOOGLE-SHEETS.md
+++ b/docs/SETUP-GOOGLE-SHEETS.md
@@ -166,17 +166,17 @@ https://docs.google.com/spreadsheets/d/e/2PACX-1vTlR2VUOcQfXRjZN4fNC-o4CvPTgd-Zl
 ### Struktur Data yang Dikirim:
 | Kolom | Deskripsi |
 |-------|-----------|
-| Timestamp | Waktu submit |
-| User ID | ID user di database |
-| NIP | NIP pegawai |
-| Nama | Nama pegawai |
-| Unit | Unit kerja |
-| Jabatan | Jabatan |
-| Nama Pelatihan | Nama pelatihan |
-| Tahun | Tahun pelatihan |
-| Pembiayaan | mandiri / yayasan |
-| Kategori | hard / soft |
-| File URL | URL file sertifikat (jika ada) |
+| Nama | Nama pegawai (otomatis dari akun yang login) |
+| Jabatan | Jabatan / posisi terakhir |
+| Unit Kerja | Unit / divisi pegawai |
+| Nama Pelatihan/Workshop/Seminar | Judul pelatihan yang diinput |
+| Tahun Penyelenggaraan | Tahun berlangsungnya pelatihan |
+| Pembiayaan | `mandiri` atau `yayasan` |
+| Kategori | `hard` atau `soft` |
+| Link Sertifikat/Bukti | Tautan file di Google Drive (atau URL asal jika upload gagal) |
+| Timestamp | Waktu submit (format `Y-m-d H:i:s`) |
+
+> **Catatan:** File sertifikat otomatis dipindahkan ke Google Drive folder `1Wpf6k5G21Zb4kAILYDL7jfCjyKZd55zp` dengan sub-folder per pegawai (`<NIP>-<Nama>`). Jika folder sudah ada maka file baru akan ditambahkan tanpa menimpa file lama.
 
 ---
 

--- a/docs/google-apps-script-training.js
+++ b/docs/google-apps-script-training.js
@@ -2,7 +2,7 @@
  * Google Apps Script untuk menerima data training dari WordPress
  *
  * Cara Deploy:
- * 1. Buka Google Sheet (1Ex3WqFgW-pkEg07-IopgIMyzcsZdirIcSEz4GRQ3UFQ)
+ * 1. Buka Google Sheet (default: 1Ex3WqFgW-pkEg07-IopgIMyzcsZdirIcSEz4GRQ3UFQ)
  * 2. Extensions → Apps Script
  * 3. Paste script ini
  * 4. Deploy → New deployment → Web app
@@ -11,93 +11,159 @@
  * 5. Copy URL dan paste ke HRISSQ Settings → Training → Web App URL
  */
 
+const DEFAULT_SHEET_ID = '1Ex3WqFgW-pkEg07-IopgIMyzcsZdirIcSEz4GRQ3UFQ';
+const DEFAULT_TAB_NAME = 'Data';
+const DEFAULT_DRIVE_FOLDER_ID = '1Wpf6k5G21Zb4kAILYDL7jfCjyKZd55zp';
+const REQUIRED_HEADERS = [
+  'Nama',
+  'Jabatan',
+  'Unit Kerja',
+  'Nama Pelatihan/Workshop/Seminar',
+  'Tahun Penyelenggaraan',
+  'Pembiayaan',
+  'Kategori',
+  'Link Sertifikat/Bukti',
+  'Timestamp',
+];
+
 function doPost(e) {
   try {
-    // Parse request body
-    const data = JSON.parse(e.postData.contents);
+    const payload = JSON.parse(e.postData && e.postData.contents ? e.postData.contents : '{}');
+    const sheetId = payload.sheetId || DEFAULT_SHEET_ID;
+    const tabName = payload.tabName || DEFAULT_TAB_NAME;
+    const driveFolderId = payload.driveFolderId || DEFAULT_DRIVE_FOLDER_ID;
+    const entry = payload.entry || payload.data || {};
 
-    // Buka Sheet berdasarkan ID dan Tab Name
-    const SHEET_ID = '1Ex3WqFgW-pkEg07-IopgIMyzcsZdirIcSEz4GRQ3UFQ';
-    const TAB_NAME = 'Data';
+    if (!sheetId) {
+      throw new Error('Sheet ID tidak ditemukan.');
+    }
 
-    const ss = SpreadsheetApp.openById(SHEET_ID);
-    const sheet = ss.getSheetByName(TAB_NAME);
-
+    const spreadsheet = SpreadsheetApp.openById(sheetId);
+    let sheet = spreadsheet.getSheetByName(tabName);
     if (!sheet) {
-      return ContentService.createTextOutput(JSON.stringify({
-        ok: false,
-        msg: 'Tab "' + TAB_NAME + '" tidak ditemukan'
-      })).setMimeType(ContentService.MimeType.JSON);
+      sheet = spreadsheet.insertSheet(tabName);
     }
 
-    // Cek header (baris pertama)
-    const headers = sheet.getRange(1, 1, 1, sheet.getLastColumn()).getValues()[0];
+    ensureHeader(sheet);
 
-    // Jika belum ada header, buat header
-    if (!headers || headers.length === 0 || headers[0] === '') {
-      sheet.appendRow([
-        'Timestamp',
-        'User ID',
-        'NIP',
-        'Nama',
-        'Unit',
-        'Jabatan',
-        'Nama Pelatihan',
-        'Tahun',
-        'Pembiayaan',
-        'Kategori',
-        'File URL'
-      ]);
+    const nama = (entry.nama || '').toString();
+    const jabatan = (entry.jabatan || '').toString();
+    const unitKerja = (entry.unit_kerja || entry.unit || '').toString();
+    const namaPelatihan = (entry.nama_pelatihan || entry.namaPelatihan || '').toString();
+    const tahun = (entry.tahun_penyelenggaraan || entry.tahun || '').toString();
+    const pembiayaan = (entry.pembiayaan || '').toString();
+    const kategori = (entry.kategori || '').toString();
+    const timestamp = entry.timestamp || new Date().toISOString();
+    const nip = (entry.nip || '').toString();
+
+    let linkBukti = entry.link_sertifikat || entry.file_url || '';
+    const fileUrl = entry.file_url || entry.link_sertifikat || '';
+
+    if (fileUrl) {
+      try {
+        linkBukti = uploadFileToDrive(fileUrl, driveFolderId, nip, nama, namaPelatihan) || linkBukti;
+      } catch (fileErr) {
+        // Jika gagal upload ke Drive, tetap gunakan link asal agar tidak hilang jejak
+        linkBukti = linkBukti || fileUrl;
+      }
     }
 
-    // Tulis data
     sheet.appendRow([
-      data.timestamp || new Date().toISOString(),
-      data.user_id || '',
-      data.nip || '',
-      data.nama || '',
-      data.unit || '',
-      data.jabatan || '',
-      data.nama_pelatihan || '',
-      data.tahun || '',
-      data.pembiayaan || '',
-      data.kategori || '',
-      data.file_url || ''
+      nama,
+      jabatan,
+      unitKerja,
+      namaPelatihan,
+      tahun,
+      pembiayaan,
+      kategori,
+      linkBukti,
+      timestamp,
     ]);
 
     return ContentService.createTextOutput(JSON.stringify({
       ok: true,
-      msg: 'Data berhasil disimpan'
+      link: linkBukti || '',
     })).setMimeType(ContentService.MimeType.JSON);
-
   } catch (error) {
     return ContentService.createTextOutput(JSON.stringify({
       ok: false,
-      msg: error.toString()
+      msg: error.toString(),
     })).setMimeType(ContentService.MimeType.JSON);
   }
 }
 
-// Test function
+function ensureHeader(sheet) {
+  const lastRow = sheet.getLastRow();
+  if (lastRow === 0) {
+    sheet.appendRow(REQUIRED_HEADERS);
+    return;
+  }
+  const headerRange = sheet.getRange(1, 1, 1, REQUIRED_HEADERS.length);
+  const current = headerRange.getValues()[0];
+  const mismatch = REQUIRED_HEADERS.some((title, idx) => (current[idx] || '') !== title);
+  if (mismatch) {
+    headerRange.setValues([REQUIRED_HEADERS]);
+  }
+}
+
+function uploadFileToDrive(url, rootFolderId, nip, nama, pelatihan) {
+  if (!rootFolderId) {
+    throw new Error('Drive Folder ID kosong.');
+  }
+  const root = DriveApp.getFolderById(rootFolderId);
+  const folderName = buildFolderName(nip, nama);
+  let targetFolder;
+  const matches = root.getFoldersByName(folderName);
+  if (matches.hasNext()) {
+    targetFolder = matches.next();
+  } else {
+    targetFolder = root.createFolder(folderName);
+  }
+
+  const response = UrlFetchApp.fetch(url, { muteHttpExceptions: true, followRedirects: true });
+  const status = response.getResponseCode();
+  if (status >= 300) {
+    throw new Error('Gagal mengambil file (HTTP ' + status + ')');
+  }
+
+  const blob = response.getBlob();
+  const safeName = sanitizeFileName(pelatihan || blob.getName() || ('Sertifikat-' + new Date().getTime()));
+  const file = targetFolder.createFile(blob).setName(safeName);
+  file.setSharing(DriveApp.Access.ANYONE_WITH_LINK, DriveApp.Permission.VIEW);
+
+  return file.getUrl();
+}
+
+function buildFolderName(nip, nama) {
+  const nipPart = nip ? nip.toString().trim() : 'UNKNOWN';
+  const namaPart = nama ? nama.toString().trim() : 'Tanpa Nama';
+  return sanitizeFileName(nipPart + '-' + namaPart);
+}
+
+function sanitizeFileName(name) {
+  return name.replace(/[\\/:*?"<>|]+/g, ' ').trim();
+}
+
+// Test function untuk verifikasi manual
 function testPost() {
-  const testData = {
-    postData: {
-      contents: JSON.stringify({
-        user_id: 1,
-        nip: '202012345678',
-        nama: 'Test User',
-        unit: 'IT',
-        jabatan: 'Staff',
-        nama_pelatihan: 'Web Development',
-        tahun: 2024,
-        pembiayaan: 'yayasan',
-        kategori: 'hard',
-        file_url: 'https://example.com/cert.pdf',
-        timestamp: new Date().toISOString()
-      })
-    }
+  const dummy = {
+    sheetId: DEFAULT_SHEET_ID,
+    tabName: DEFAULT_TAB_NAME,
+    driveFolderId: DEFAULT_DRIVE_FOLDER_ID,
+    entry: {
+      nip: '202012345678',
+      nama: 'Test User',
+      jabatan: 'Staff IT',
+      unit_kerja: 'Divisi Teknologi',
+      nama_pelatihan: 'Workshop Integrasi HRIS',
+      tahun_penyelenggaraan: '2024',
+      pembiayaan: 'yayasan',
+      kategori: 'hard',
+      link_sertifikat: 'https://example.com/certificate.pdf',
+      timestamp: new Date().toISOString(),
+    },
   };
 
-  const result = doPost(testData);
+  const result = doPost({ postData: { contents: JSON.stringify(dummy) } });
   Logger.log(result.getContent());
 }

--- a/hrissq.php
+++ b/hrissq.php
@@ -100,6 +100,7 @@ add_action('wp_ajax_nopriv_hrissq_forgot', ['HRISSQ\\Api','forgot_password']);
  * ======================================================= */
 add_action('wp_ajax_nopriv_hrissq_login',    ['HRISSQ\\Api', 'login']);
 add_action('wp_ajax_hrissq_logout',          ['HRISSQ\\Api', 'logout']);
+add_action('wp_ajax_nopriv_hrissq_logout',   ['HRISSQ\\Api', 'logout']);
 add_action('wp_ajax_hrissq_submit_training', ['HRISSQ\\Api', 'submit_training']);
 // non-logged user dilarang submit
 add_action('wp_ajax_nopriv_hrissq_submit_training', function(){

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -55,9 +55,15 @@ class Admin {
         $sheet_id = sanitize_text_field($_POST['training_sheet_id'] ?? '');
         $tab_name = sanitize_text_field($_POST['training_tab_name'] ?? 'Data');
         $webapp_url = esc_url_raw($_POST['training_webapp_url'] ?? '');
+        $drive_folder = sanitize_text_field($_POST['training_drive_folder_id'] ?? '');
 
         Trainings::set_sheet_config($sheet_id, $tab_name);
         Trainings::set_webapp_url($webapp_url);
+        if ($drive_folder) {
+          Trainings::set_drive_folder_id($drive_folder);
+        } else {
+          delete_option(Trainings::OPT_TRAINING_DRIVE_FOLDER_ID);
+        }
 
         $msg .= "<strong>Training config saved.</strong><br>";
       }
@@ -68,6 +74,7 @@ class Admin {
     $users_tab_name = esc_attr(Users::get_tab_name());
     $training_sheet_id = esc_attr(Trainings::get_sheet_id());
     $training_tab_name = esc_attr(Trainings::get_tab_name());
+    $training_drive_folder = esc_attr(Trainings::get_drive_folder_id());
     $training_webapp_url = esc_url(Trainings::get_webapp_url());
     ?>
     <div class="wrap">
@@ -143,6 +150,14 @@ class Admin {
             <td>
               <input type="text" id="training_tab_name" name="training_tab_name" class="regular-text"
                      value="<?= $training_tab_name ?>" placeholder="Data">
+            </td>
+          </tr>
+          <tr>
+            <th scope="row"><label for="training_drive_folder_id">Drive Folder ID</label></th>
+            <td>
+              <input type="text" id="training_drive_folder_id" name="training_drive_folder_id" class="regular-text" style="width: 600px"
+                     value="<?= $training_drive_folder ?>" placeholder="1Wpf6k5G21Zb4kAILYDL7jfCjyKZd55zp">
+              <p class="description">File sertifikat akan disimpan di folder Google Drive ini (sub-folder otomatis: <code>&lt;NIP&gt;-&lt;Nama&gt;</code>).</p>
             </td>
           </tr>
           <tr>

--- a/includes/View.php
+++ b/includes/View.php
@@ -10,40 +10,44 @@ class View {
     wp_enqueue_style('hrissq');
     wp_enqueue_script('hrissq');
     ob_start(); ?>
-    <div class="hrissq-auth-wrap">
-      <div class="auth-card">
-        <h2>Hubungi Kami<br> Sekarang</h2>
-
-        <form id="hrissq-login-form" class="auth-form">
-          <label>NIP <span class="req">*</span></label>
-          <input type="text" name="nip" placeholder="2020xxxxxxxxxxxx" autocomplete="username" required>
-
-          <label>Password <span class="req">*</span></label>
-          <div class="pw-row">
-            <input id="hrissq-pw" type="password" name="pw" placeholder="No HP (62812xxxxxxx)" autocomplete="current-password" required>
-            <button type="button" id="hrissq-eye" class="eye">lihat</button>
+    <div id="hrissq-app" class="hrissq-app">
+      <div class="hrissq-auth-wrap">
+        <div class="auth-card">
+          <div class="auth-header">
+            <h2>Masuk ke Akun Guru/Pegawai</h2>
           </div>
 
-          <button type="submit" class="btn-primary">Masuk</button>
+          <form id="hrissq-login-form" class="auth-form">
+            <label>Akun <span class="req">*</span></label>
+            <input type="text" name="nip" placeholder="Masukkan NIP" autocomplete="username" required>
 
-          <button type="button" id="hrissq-forgot" class="link-forgot">Lupa password?</button>
-          <div class="msg" aria-live="polite"></div>
-        </form>
-      </div>
-    </div>
+            <label>Pasword <span class="req">*</span></label>
+            <div class="pw-row">
+              <input id="hrissq-pw" type="password" name="pw" placeholder="Gunakan No HP" autocomplete="current-password" required>
+              <button type="button" id="hrissq-eye" class="eye">lihat</button>
+            </div>
 
-    <!-- Modal Lupa Password -->
-    <div id="hrissq-modal" class="modal-backdrop" style="display:none;">
-      <div class="modal">
-        <h3>Lupa Password</h3>
-        <p>Masukkan NIP Anda. Kami akan mengirim permintaan ke Admin HCM.</p>
-        <label>NIP</label>
-        <input id="hrissq-nip-forgot" type="text" placeholder="2020xxxxxxxxxxxx">
-        <div class="modal-actions">
-          <button type="button" class="btn-light" id="hrissq-cancel">Batal</button>
-          <button type="button" class="btn-primary" id="hrissq-send">Kirim</button>
+            <button type="submit" class="btn-primary">Masuk</button>
+
+            <button type="button" id="hrissq-forgot" class="link-forgot">Lupa pasword?</button>
+            <div class="msg" aria-live="polite"></div>
+          </form>
         </div>
-        <div id="hrissq-forgot-msg" class="modal-msg"></div>
+      </div>
+
+      <!-- Modal Lupa Password -->
+      <div id="hrissq-modal" class="modal-backdrop" style="display:none;">
+        <div class="modal">
+          <h3>Lupa Pasword</h3>
+          <p>Masukkan Akun (NIP) Anda. Kami akan mengirim permintaan ke Admin HCM.</p>
+          <label>Akun (NIP)</label>
+          <input id="hrissq-nip-forgot" type="text" placeholder="Masukkan NIP">
+          <div class="modal-actions">
+            <button type="button" class="btn-light" id="hrissq-cancel">Batal</button>
+            <button type="button" class="btn-primary" id="hrissq-send">Kirim</button>
+          </div>
+          <div id="hrissq-forgot-msg" class="modal-msg"></div>
+        </div>
       </div>
     </div>
     <?php
@@ -55,114 +59,151 @@ class View {
     $me = Auth::current_user();
     if (!$me) { wp_safe_redirect(site_url('/'.HRISSQ_LOGIN_SLUG)); exit; }
 
-    // ambil profil mirror (jika tersedia)
-    $prof = null;
-    if (class_exists('\\HRISSQ\\Profiles') && method_exists('\\HRISSQ\\Profiles','get_by_nip')) {
-      $prof = \HRISSQ\Profiles::get_by_nip($me->nip);
+    $unit    = $me->unit ?? '';
+    $role    = $me->jabatan ?? '';
+    $phone   = $me->no_hp ?? '';
+    $email   = $me->email ?? '';
+    $status  = $me->status_kepegawaian ?? '';
+
+    $training_link = Trainings::build_webapp_link($me->nip ?? '', $me->nama ?? '');
+    if (!$training_link) {
+      $training_link = site_url('/' . HRISSQ_FORM_SLUG);
     }
+
+    $profile_rows = [
+      ['label' => 'Nama',          'value' => $me->nama ?? '-'],
+      ['label' => 'Akun (NIP)',    'value' => $me->nip ?? '-'],
+      ['label' => 'Status Aktif',  'value' => ($me->status_aktif ?? '') !== '' ? $me->status_aktif : '-'],
+      ['label' => 'Status Pegawai','value' => $status !== '' ? $status : '-'],
+    ];
 
     wp_enqueue_style('hrissq');
     wp_enqueue_script('hrissq');
 
     ob_start(); ?>
-    <div class="hrissq-dashboard">
+    <div id="hrissq-app" class="hrissq-app">
+      <div class="hrissq-dashboard" id="hrissq-dashboard">
 
-      <!-- Sidebar -->
-      <aside class="sidebar">
-        <div class="logo"><span>SQ Pegawai</span></div>
-        <nav>
-          <a href="<?= esc_url(site_url('/'.HRISSQ_DASHBOARD_SLUG)) ?>">Dashboard</a>
-          <a href="#">Profil</a>
-          <a href="#">Slip Gaji</a>
-          <a href="#">Rekap Absensi</a>
-          <a href="#">Riwayat Kepegawaian</a>
-          <a href="#">Cuti & Izin</a>
-          <a href="#">Penilaian Kinerja</a>
-          <a href="#">Tugas & Komunikasi</a>
-          <a href="#">Administrasi Lain</a>
-          <hr>
-          <a href="#">Panduan</a>
-          <a href="#">Support</a>
-        </nav>
-      </aside>
+        <!-- Sidebar -->
+        <aside class="hrissq-sidebar" id="hrissq-sidebar" aria-label="Navigasi utama">
+          <div class="hrissq-sidebar-header">
+            <span class="hrissq-sidebar-logo">SQ Pegawai</span>
+            <button type="button" class="hrissq-icon-button hrissq-sidebar-close" id="hrissq-sidebar-close" aria-label="Tutup menu navigasi">
+              <span aria-hidden="true">×</span>
+            </button>
+          </div>
+          <nav class="hrissq-sidebar-nav">
+            <a class="is-active" href="<?= esc_url(site_url('/'.HRISSQ_DASHBOARD_SLUG)) ?>">Dashboard</a>
+            <a href="#">Profil</a>
+            <a href="#">Slip Gaji</a>
+            <a href="#">Rekap Absensi</a>
+            <a href="#">Riwayat Kepegawaian</a>
+            <a href="#">Cuti &amp; Izin</a>
+            <a href="#">Penilaian Kinerja</a>
+            <a href="#">Tugas &amp; Komunikasi</a>
+            <a href="#">Administrasi Lain</a>
+            <hr>
+            <a href="#">Panduan</a>
+            <a href="#">Support</a>
+          </nav>
+          <div class="hrissq-sidebar-meta">
+            <span>Versi <?= esc_html(HRISSQ_VER) ?></span>
+          </div>
+        </aside>
 
-      <!-- Main -->
-      <main class="content">
-        <!-- Header -->
-        <header class="topbar">
-          <h2>Dashboard Pegawai</h2>
-          <div class="user-menu">
-            <span class="user-name"><?= esc_html($me->nama) ?></span>
-            <div class="dropdown">
-              <a href="#">Perbarui Profil</a>
-              <a href="#">Ganti Password</a>
-              <a href="#" id="hrissq-logout">Keluar</a>
+        <div class="hrissq-sidebar-overlay" id="hrissq-sidebar-overlay" aria-hidden="true"></div>
+
+        <!-- Main -->
+        <main class="hrissq-main">
+          <header class="hrissq-topbar">
+            <div class="hrissq-topbar-left">
+              <button type="button" class="hrissq-icon-button hrissq-menu-toggle" id="hrissq-sidebar-toggle" aria-label="Buka menu navigasi" aria-expanded="true">
+                <span></span>
+                <span></span>
+                <span></span>
+              </button>
+              <div>
+                <h1 class="hrissq-page-title">Dashboard Pegawai</h1>
+                <p class="hrissq-page-subtitle">Ringkasan informasi kepegawaian.</p>
+              </div>
             </div>
+            <div class="hrissq-user">
+              <div class="hrissq-user-meta">
+                <span class="hrissq-user-name"><?= esc_html($me->nama) ?></span>
+                <span class="hrissq-user-role">Akun: <?= esc_html($me->nip ?? '-') ?></span>
+              </div>
+              <button type="button" class="btn-light" id="hrissq-logout">Keluar</button>
+            </div>
+          </header>
+
+          <div class="hrissq-main-body">
+            <section class="hrissq-card-grid hrissq-card-grid--3">
+              <article class="hrissq-card">
+                <h3 class="hrissq-card-title">Profil Ringkas</h3>
+                <dl class="hrissq-meta-list">
+                  <?php foreach ($profile_rows as $row): ?>
+                    <div>
+                      <dt><?= esc_html($row['label']) ?></dt>
+                      <dd><?= esc_html($row['value']) ?></dd>
+                    </div>
+                  <?php endforeach; ?>
+                </dl>
+              </article>
+
+              <article class="hrissq-card">
+                <h3 class="hrissq-card-title">Unit &amp; Jabatan</h3>
+                <dl class="hrissq-meta-list">
+                  <div>
+                    <dt>Unit</dt>
+                    <dd><?= esc_html($unit !== '' ? $unit : '-') ?></dd>
+                  </div>
+                  <div>
+                    <dt>Jabatan</dt>
+                    <dd><?= esc_html($role !== '' ? $role : '-') ?></dd>
+                  </div>
+                </dl>
+              </article>
+
+              <article class="hrissq-card">
+                <h3 class="hrissq-card-title">Kontak Utama</h3>
+                <dl class="hrissq-meta-list">
+                  <div>
+                    <dt>No. HP</dt>
+                    <dd><?= esc_html($phone !== '' ? $phone : '-') ?></dd>
+                  </div>
+                  <div>
+                    <dt>Email</dt>
+                    <dd><?= esc_html($email !== '' ? $email : '-') ?></dd>
+                  </div>
+                </dl>
+              </article>
+            </section>
+
+            <section class="hrissq-card-grid hrissq-card-grid--2">
+              <article class="hrissq-card">
+                <h3 class="hrissq-card-title">Pengumuman</h3>
+                <ul class="hrissq-bullet-list">
+                  <li><strong><a href="<?= esc_url($training_link) ?>" target="_blank" rel="noopener">Pembaruan Data Pegawai</a></strong> – Lengkapi form untuk memastikan data layanan terkini.</li>
+                  <li><strong><a href="https://ppdb.sabilulquran.or.id" target="_blank" rel="noopener">SPMB 2026/2027</a></strong> – Pendaftaran peserta baru telah dibuka.</li>
+                  <li><strong><a href="https://instagram.com/sabilulquran" target="_blank" rel="noopener">Ikuti Sabilul Qur'an di Instagram</a></strong> – Dapatkan kabar terbaru komunitas.</li>
+                </ul>
+              </article>
+            </section>
           </div>
-        </header>
+        </main>
+      </div>
 
-        <!-- Cards -->
-        <section class="cards">
-          <div class="card">
-            <h3>Status Data</h3>
-            <p>Butuh Pembaruan.<br>Lengkapi riwayat pelatihan Anda.</p>
-            <a href="<?= esc_url(site_url('/'.HRISSQ_FORM_SLUG)) ?>">Isi Form Pelatihan →</a>
+      <!-- Modal Auto-Logout (Idle) -->
+      <div id="hrq-idle-backdrop" class="modal-backdrop" style="display:none;">
+        <div class="modal">
+          <h3>Sesi Akan Berakhir</h3>
+          <p>Anda tidak aktif cukup lama. Otomatis keluar dalam
+            <b><span id="hrq-idle-count">30</span> detik</b>.
+          </p>
+          <div class="modal-actions">
+            <button id="hrq-idle-stay" class="btn-light">Batalkan</button>
+            <button id="hrq-idle-exit" class="btn-primary">Keluar Sekarang</button>
           </div>
-
-          <div class="card">
-            <h3>Unit & Jabatan</h3>
-            <p>
-              <?= esc_html($prof->unit ?? $me->unit ?? '-') ?><br>
-              Jabatan: <?= esc_html($prof->jabatan ?? $me->jabatan ?? '-') ?>
-            </p>
-          </div>
-
-          <div class="card">
-            <h3>Profil Ringkas</h3>
-            <?php if ($prof): ?>
-              <p>
-                <b><?= esc_html($prof->nama) ?></b><br>
-                NIP: <?= esc_html($prof->nip) ?><br>
-                TTL: <?= esc_html(($prof->tempat_lahir ?: '-').', '.($prof->tanggal_lahir ?: '-')) ?><br>
-                HP: <?= esc_html($prof->hp ?: '-') ?> • Email: <?= esc_html($prof->email ?: '-') ?><br>
-                Alamat KTP: <?= esc_html($prof->alamat_ktp ?: '-') ?>,
-                <?= esc_html($prof->desa ?: '-') ?>, <?= esc_html($prof->kecamatan ?: '-') ?>,
-                <?= esc_html($prof->kota ?: '-') ?> <?= esc_html($prof->kode_pos ?: '') ?><br>
-                TMT: <?= esc_html($prof->tmt ?: '-') ?>
-              </p>
-            <?php else: ?>
-              <p>Belum ada data profil untuk NIP ini. (Coba jalankan import CSV di Tools → HRISSQ Import)</p>
-            <?php endif; ?>
-          </div>
-
-          <div class="card">
-            <h3>Pengumuman</h3>
-            <p>SPMB Dibuka.<br>Cek info terbaru di bawah.</p>
-          </div>
-        </section>
-
-        <!-- News / Announcement -->
-        <section class="news">
-          <h3>Berita & Pengumuman</h3>
-          <ul>
-            <li><b>Pembaruan Data Pegawai</b> – Segera isi form profil terbaru.</li>
-            <li><b>SPMB 2026/2027</b> – Pendaftaran telah dibuka.</li>
-            <li><b>Agenda Internal</b> – Training Sabtu pekan ini.</li>
-          </ul>
-        </section>
-      </main>
-    </div>
-
-    <!-- Modal Auto-Logout (Idle) -->
-    <div id="hrq-idle-backdrop" class="modal-backdrop" style="display:none;">
-      <div class="modal">
-        <h3>Sesi Akan Berakhir</h3>
-        <p>Anda tidak aktif cukup lama. Otomatis keluar dalam
-          <b><span id="hrq-idle-count">30</span> detik</b>.
-        </p>
-        <div class="modal-actions">
-          <button id="hrq-idle-stay" class="btn-light">Batalkan</button>
-          <button id="hrq-idle-exit" class="btn-primary">Keluar Sekarang</button>
         </div>
       </div>
     </div>
@@ -179,48 +220,50 @@ class View {
     wp_enqueue_script('hrissq');
 
     ob_start(); ?>
-    <div class="hrissq-form-wrap">
-      <h2>Form Riwayat Pelatihan</h2>
-      <p>Lengkapi data pelatihan yang telah Anda ikuti.</p>
+    <div id="hrissq-app" class="hrissq-app">
+      <div class="hrissq-form-wrap">
+        <h2>Form Riwayat Pelatihan</h2>
+        <p>Lengkapi data pelatihan yang telah Anda ikuti.</p>
 
-      <form id="hrissq-training-form" enctype="multipart/form-data" class="training-form">
-        <div class="form-group">
-          <label>Nama Pelatihan <span class="req">*</span></label>
-          <input type="text" name="nama_pelatihan" placeholder="Contoh: Workshop Laravel" required>
-        </div>
+        <form id="hrissq-training-form" enctype="multipart/form-data" class="training-form">
+          <div class="form-group">
+            <label>Nama Pelatihan <span class="req">*</span></label>
+            <input type="text" name="nama_pelatihan" placeholder="Contoh: Workshop Laravel" required>
+          </div>
 
-        <div class="form-group">
-          <label>Tahun <span class="req">*</span></label>
-          <input type="number" name="tahun" placeholder="2024" min="1990" max="2099" required>
-        </div>
+          <div class="form-group">
+            <label>Tahun <span class="req">*</span></label>
+            <input type="number" name="tahun" placeholder="2024" min="1990" max="2099" required>
+          </div>
 
-        <div class="form-group">
-          <label>Pembiayaan <span class="req">*</span></label>
-          <select name="pembiayaan" required>
-            <option value="">Pilih Pembiayaan</option>
-            <option value="mandiri">Mandiri</option>
-            <option value="yayasan">Yayasan</option>
-          </select>
-        </div>
+          <div class="form-group">
+            <label>Pembiayaan <span class="req">*</span></label>
+            <select name="pembiayaan" required>
+              <option value="">Pilih Pembiayaan</option>
+              <option value="mandiri">Mandiri</option>
+              <option value="yayasan">Yayasan</option>
+            </select>
+          </div>
 
-        <div class="form-group">
-          <label>Kategori <span class="req">*</span></label>
-          <select name="kategori" required>
-            <option value="">Pilih Kategori</option>
-            <option value="hard">Hard Skill</option>
-            <option value="soft">Soft Skill</option>
-          </select>
-        </div>
+          <div class="form-group">
+            <label>Kategori <span class="req">*</span></label>
+            <select name="kategori" required>
+              <option value="">Pilih Kategori</option>
+              <option value="hard">Hard Skill</option>
+              <option value="soft">Soft Skill</option>
+            </select>
+          </div>
 
-        <div class="form-group">
-          <label>Upload Sertifikat (opsional)</label>
-          <input type="file" name="sertifikat" accept=".pdf,.jpg,.jpeg,.png">
-          <small>Format: PDF, JPG, PNG (max 5MB)</small>
-        </div>
+          <div class="form-group">
+            <label>Upload Sertifikat (opsional)</label>
+            <input type="file" name="sertifikat" accept=".pdf,.jpg,.jpeg,.png">
+            <small>Format: PDF, JPG, PNG (max 5MB)</small>
+          </div>
 
-        <button type="submit" class="btn-primary">Simpan</button>
-        <a href="<?= esc_url(site_url('/'.HRISSQ_DASHBOARD_SLUG)) ?>" class="btn-light">Batal</a>
-      </form>
+          <button type="submit" class="btn-primary">Simpan</button>
+          <a href="<?= esc_url(site_url('/'.HRISSQ_DASHBOARD_SLUG)) ?>" class="btn-light">Batal</a>
+        </form>
+      </div>
     </div>
     <?php
     return ob_get_clean();


### PR DESCRIPTION
## Summary
- brighten glass variables and components so login/dashboard text stays legible while retaining a transparent theme
- restructure dashboard profile/contact cards for a shorter layout and surface contact details alongside unit and jabatan
- generate a signed Google Apps Script URL that pre-fills nip and nama for the training form announcement link

## Testing
- php -l includes/View.php
- php -l includes/Trainings.php

------
https://chatgpt.com/codex/tasks/task_e_68dd2ceb5a288323ae38edf3a382f09e