### PR TITLE
Fix login form layout and modal controls

### DIFF
--- a/assets/app.css
+++ b/assets/app.css
@@ -152,12 +152,14 @@ p{margin:0 0 6px}
 
 /* Modal */
 .modal-backdrop{position:fixed;inset:0;background:rgba(0,0,0,.5);display:flex;align-items:center;justify-content:center;padding:12px;z-index:50}
-.modal{background:rgba(255,255,255,.95);border-radius:14px;max-width:360px;width:100%;padding:16px;border:1px solid rgba(15,23,42,.2);color:#0f172a;backdrop-filter:blur(16px)}
+.modal{position:relative;background:rgba(255,255,255,.95);border-radius:14px;max-width:360px;width:100%;padding:16px 16px 18px;border:1px solid rgba(15,23,42,.2);color:#0f172a;backdrop-filter:blur(16px)}
 .modal h3{margin:0 0 6px;font-size:var(--font-heading);font-weight:700}
 .modal p{font-size:var(--font-body)}
 .modal .modal-actions{display:flex;gap:6px;justify-content:flex-end;margin-top:10px}
 .modal input{width:100%;padding:9px 12px;border:1px solid rgba(15,23,42,.25);border-radius:10px;background:rgba(255,255,255,.9);color:#0f172a;font-size:11px}
 .modal-msg{margin-top:6px;font-size:10px}
+.modal-close{position:absolute;top:10px;right:10px;background:transparent;border:none;font-size:18px;line-height:1;color:rgba(15,23,42,.6);cursor:pointer;padding:0;width:26px;height:26px;border-radius:50%;transition:background .2s ease,color .2s ease}
+.modal-close:hover{background:rgba(15,23,42,.08);color:rgba(15,23,42,.85)}
 
 /* Training Form */
 .hrissq-form-wrap{

--- a/assets/app.js
+++ b/assets/app.js
@@ -94,17 +94,24 @@
     const forgotBtn = document.getElementById('hrissq-forgot');
     const backdrop = document.getElementById('hrissq-modal');
     const cancelBtn = document.getElementById('hrissq-cancel');
+    const closeBtn = document.getElementById('hrissq-close-modal');
     const sendBtn = document.getElementById('hrissq-send');
     const npInput = document.getElementById('hrissq-nip-forgot');
     const fMsg = document.getElementById('hrissq-forgot-msg');
 
     if (forgotBtn && backdrop) {
+      const closeModal = () => {
+        backdrop.style.display = 'none';
+        if (fMsg) { fMsg.className = 'modal-msg'; fMsg.textContent = ''; }
+      };
+
       forgotBtn.onclick = () => {
         backdrop.style.display = 'flex';
         if (npInput) npInput.value = (form.nip.value || '').trim();
         if (fMsg) { fMsg.className = 'modal-msg'; fMsg.textContent = ''; }
       };
-      cancelBtn && (cancelBtn.onclick = () => { backdrop.style.display = 'none'; });
+      cancelBtn && (cancelBtn.onclick = closeModal);
+      closeBtn && (closeBtn.onclick = closeModal);
       sendBtn && (sendBtn.onclick = () => {
         const nip = (npInput.value || '').trim();
         if (!nip) { fMsg.textContent = 'Akun wajib diisi.'; return; }
@@ -116,7 +123,7 @@
             if (res && res.ok) {
               fMsg.className = 'modal-msg ok';
               fMsg.textContent = 'Permintaan terkirim. Anda akan dihubungi Admin via WhatsApp.';
-              setTimeout(() => { backdrop.style.display = 'none'; }, 1500);
+              setTimeout(closeModal, 1500);
             } else {
               fMsg.className = 'modal-msg';
               fMsg.textContent = 'Gagal mengirim permintaan. Coba lagi.';

--- a/includes/View.php
+++ b/includes/View.php
@@ -17,26 +17,25 @@ class View {
         </div>
 
         <form id="hrissq-login-form" class="auth-form">
-          <label>Akun <span class="req">*</span></label>
-          <input type="text" name="nip" placeholder="Masukkan NIP" autocomplete="username" required>
+          <label for="hrissq-nip">Akun <span class="req">*</span></label>
+          <input id="hrissq-nip" type="text" name="nip" placeholder="Masukkan NIP" autocomplete="username" required>
 
-          <label>Pasword <span class="req">*</span></label>
+          <label for="hrissq-pw">Pasword <span class="req">*</span></label>
           <div class="pw-row">
             <input id="hrissq-pw" type="password" name="pw" placeholder="Gunakan No HP" autocomplete="current-password" required>
             <button type="button" id="hrissq-eye" class="eye">lihat</button>
           </div>
 
-          <form id="hrissq-login-form" class="auth-form">
-            <label>Akun <span class="req">*</span></label>
-            <input type="text" name="nip" placeholder="Masukkan NIP" autocomplete="username" required>
+          <button type="submit" class="btn-primary">Masuk</button>
           <button type="button" id="hrissq-forgot" class="link-forgot">Lupa pasword?</button>
           <div class="msg" aria-live="polite"></div>
         </form>
       </div>
     <!-- Modal Lupa Password -->
-    <div id="hrissq-modal" class="modal-backdrop" style="display:none;">
+    <div id="hrissq-modal" class="modal-backdrop" style="display:none;" role="dialog" aria-modal="true" aria-labelledby="hrissq-forgot-title">
       <div class="modal">
-        <h3>Lupa Pasword</h3>
+        <button type="button" class="modal-close" id="hrissq-close-modal" aria-label="Tutup">×</button>
+        <h3 id="hrissq-forgot-title">Lupa Pasword</h3>
         <p>Masukkan Akun (NIP) Anda. Kami akan mengirim permintaan ke Admin HCM.</p>
         <label>Akun (NIP)</label>
         <input id="hrissq-nip-forgot" type="text" placeholder="Masukkan NIP">
@@ -44,6 +43,7 @@ class View {
           <button type="button" class="btn-light" id="hrissq-cancel">Batal</button>
           <button type="button" class="btn-primary" id="hrissq-send">Kirim</button>
         </div>
+        <div id="hrissq-forgot-msg" class="modal-msg" aria-live="polite"></div>
       </div>
     </div>
     <?php


### PR DESCRIPTION
## Summary
- restore the login form to a single submission with the correct NIP and password fields
- add close behaviour and feedback handling to the forgot password modal
- style the modal close control to match the rest of the UI

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e060a5bcf88323bc6f2978b2c339ed